### PR TITLE
Retrieve XCSRF for newer APIs

### DIFF
--- a/lib/util/http.js
+++ b/lib/util/http.js
@@ -65,7 +65,7 @@ exports.func = function (args) {
   }
   return http(args.url, opt).then(function (res) {
     if (opt && opt.headers && opt.headers['X-CSRF-TOKEN']) {
-      if (res.statusCode === 403 && res.statusMessage === 'XSRF Token Validation Failed') {
+      if (res.statusCode === 403 && (res.statusMessage === 'XSRF Token Validation Failed' || res.statusMessage === 'Token Validation Failed')) {
         depth++
         if (depth >= 3) {
           throw new Error('Tried ' + depth + ' times and could not refresh XCSRF token successfully')


### PR DESCRIPTION
New APIs have a different status message.

This should address #23 