### PR TITLE
Add cookieLogin bypass

### DIFF
--- a/lib/user/cookieLogin.js
+++ b/lib/user/cookieLogin.js
@@ -1,0 +1,19 @@
+// Allows user to login with a cookie.json, bypassing the username/password captcha issues.
+// Includes
+var relog = require('../util/relog.js')
+// Args
+exports.required = ['cookie']
+exports.optional = []
+var interval
+var day = 86400000
+exports.func = function (args) {
+  // Run relog
+  return relog(args.cookie)
+    .then(function (r) {
+      // Start interval
+      if (!interval) {
+        setInterval(relog, day)
+      }
+      return r
+    })
+}

--- a/lib/util/relog.js
+++ b/lib/util/relog.js
@@ -1,0 +1,81 @@
+// Includes
+var options = require('../options.js')
+var getGeneralToken = require('./getGeneralToken.js').func
+var getVerification = require('./getVerification.js').func
+var getCurrentUser = require('./getCurrentUser.js').func
+var http = require('./http.js').func
+var cookieFile = './cookie'
+var fs = require('fs')
+// Args
+exports.required = ['cookie']
+exports.optional = []
+
+var day = 86400000
+
+// Define
+const relog = (cookie) => {
+  if (!cookie) throw new Error('no cookie supplied?')
+  options.jar.session = cookie
+  return getVerification({url: 'https://www.roblox.com/my/account#!/security'})
+    .then((ver) => {
+      if (!ver.header) console.log(`Bad cookie.`)
+      return getGeneralToken({}).then((token) => {
+        return http({
+          url: 'https://www.roblox.com/authentication/signoutfromallsessionsandreauthenticate',
+          options: {
+            method: 'POST',
+            resolveWithFullResponse: true,
+            verification: ver.header,
+            jar: null,
+            headers: {
+              'X-CSRF-TOKEN': token
+            },
+            form: {
+              __RequestVerificationToken: ver.inputs.__RequestVerificationToken
+            }
+          }
+        }).then((res) => {
+          var cookies = res.headers['set-cookie']
+          if (cookies) {
+            options.jar.session = cookies.toString().match(/\.ROBLOSECURITY=(.*?);/)[1]
+
+            fs.writeFile(cookieFile, JSON.stringify({cookie: options.jar.session, time: Date.now()}), (err) => {
+              if (err) {
+                console.error('Failed to write cookie')
+              }
+              return true
+            })
+          }
+        })
+      })
+    })
+}
+module.exports = c
+
+async function c (cookie) {
+  // Check for file
+  if (fs.existsSync(cookieFile)) {
+    var json = JSON.parse(fs.readFileSync(cookieFile))
+
+    // Check its new enough
+    if (json.time + day > Date.now()) {
+      // Its recent enough. Try it.
+      try {
+        await relog(json.cookie)
+        return getCurrentUser({})
+      } catch (e) {
+        console.log(`Stored relog failed. Trying with given.`)
+      }
+    }
+  }
+  if (cookie) {
+    // Try the user's cookie
+    try {
+      await relog(cookie)
+      return getCurrentUser({})
+    } catch (e) {
+      console.error(e)
+    }
+  }
+  throw new Error('No cookie supplied and no cookie file available.')
+}


### PR DESCRIPTION
This new method makes use of Froast's relog function. It's to bypass the login captcha introduced by Roblox recently.

How to use:
- Login to your bot account manually
- Open inspect element (if it's chrome, Control + Shift + i)
- Click "Application"
- Click "Cookies"
- Copy .roblosecurity and run cookieLogin with it

All other sessions for that account will be invalidated and a new token will be stored internally.

After this, all you need to do is run cookieLogin with no parameters. Tokens will be automatically regenerated once a day. Any params will be ignored unless the internal cookie file is out of date.