### PR TITLE
Fixed shout.js using new API

### DIFF
--- a/lib/group/shout.js
+++ b/lib/group/shout.js
@@ -1,23 +1,58 @@
 // Includes
-var generalRequest = require('../util/generalRequest.js').func
+var http = require('../util/http.js').func
+var getGeneralToken = require('../util/getGeneralToken.js').func
 
 // Args
 exports.required = ['group']
 exports.optional = ['message', 'jar']
 
-// Define
-exports.func = function (args) {
-  var jar = args.jar
-  var group = args.group
-  var message = args.message || ''
-  var events = {
-    ctl00$cphRoblox$GroupStatusPane$StatusTextBox: message,
-    ctl00$cphRoblox$GroupStatusPane$StatusSubmitButton: 'Group Shout'
-  }
-  return generalRequest({jar: jar, url: '//www.roblox.com/My/Groups.aspx?gid=' + group, events: events})
-    .then(function (result) {
-      if (result.res.statusCode !== 200) {
-        throw new Error('Shout failed, verify login, permissions, and message')
+function shoutOnGroup (group, shoutMessage, jar, xcsrf) {
+  var httpOpt = {
+    url: `https://groups.roblox.com/v1/groups/${group}/status`,
+    options: {
+      method: 'PATCH',
+      resolveWithFullResponse: true,
+      json: {
+        message: shoutMessage
+      },
+      jar: jar,
+      headers: {
+        'X-CSRF-TOKEN': xcsrf
       }
-    })
+    }
+  }
+
+  return http(httpOpt)
+  .then(function(res) {
+    if(res.statusCode === 403) {
+      throw new Error('Token Validation Failed - Failed to verify XCSRF Token.')
+    }
+    if(res.statusCode === 401) {
+      throw new Error('Shout failed, verify that you are logged in.')
+    }
+    if(res.statusCode === 400) {
+      let resErrors = res.body.errors
+      for (let i = 0; i < resErrors.length; i++) { 
+        let resError = resErrors[i]
+        if(resError.code === 7) {
+          throw new Error('Shout failed, verify that you are providing a message to shout.')
+        }
+        if(resError.code === 6) {
+          throw new Error('Shout failed, verify that the logged in user has permissions to shout.')
+        }
+        if(resError.code === 1) {
+          throw new Error('Shout failed, verify that the group provided exists.')
+        }
+      }
+    }
+  })
+}
+
+// Define
+exports.func = function(args) {
+  let jar = args.jar
+  return getGeneralToken({jar: jar})
+  .then(function(xcsrf) {
+    return shoutOnGroup(args.group, args.message, args.jar, xcsrf)
+  })
 }


### PR DESCRIPTION
Redid shout.js using the new [Group Shout API](https://groups.roblox.com/docs#!/Groups/patch_v1_groups_groupId_status).