### PR TITLE
Replace URL with /users/profile/profileheader-json

### DIFF
--- a/lib/user/getBlurb.js
+++ b/lib/user/getBlurb.js
@@ -1,6 +1,5 @@
 // Includes
 var http = require('../util/http.js').func
-var parser = require('cheerio')
 
 // Args
 exports.required = ['userId']
@@ -8,15 +7,17 @@ exports.required = ['userId']
 // Define
 exports.func = function (args) {
   return http({
-    url: '//www.roblox.com/users/' + args.userId + '/profile',
+    url: '//www.roblox.com/users/profile/profileheader-json?userid=' + args.userId,
     options: {
       resolveWithFullResponse: true,
-      followRedirect: false
+      followRedirect: false,
+      method: 'GET'
     }
   })
     .then(function (res) {
       if (res.statusCode === 200) {
-        return parser.load(res.body)('.profile-about-content-text').text()
+        var json = JSON.parse(res.body)
+        return json.UserStatus
       } else {
         throw new Error('User does not exist')
       }


### PR DESCRIPTION
In my testing, loading the average User Profile can take about 2.5s while loading the profileheader-json only takes around 0.5s or less. This also allows for reading the status of terminated users (although that isn't necessarily the point of this change)