### PR TITLE
Fix for exile.js

### DIFF
--- a/lib/group/exile.js
+++ b/lib/group/exile.js
@@ -26,7 +26,7 @@ function exileUser(group, target, jar, xcsrf) {
         resolve()
       }
       if(res.statusCode === 400) {
-        let resErrors = res.body.errors
+        let resErrors = JSON.parse(res.body).errors
         for (let i = 0; i < resErrors.length; i++) { 
           let resError = resErrors[i]
           if(resError.code === 1) {
@@ -41,7 +41,7 @@ function exileUser(group, target, jar, xcsrf) {
         reject(new Error('Authorization has been denied for this request. Ensure you are logged in.'))
       }
       if(res.statusCode === 403) {
-        let resErrors = res.body.errors
+        let resErrors = JSON.parse(res.body).errors
         for (let i = 0; i < resErrors.length; i++) { 
           let resError = resErrors[i]
           if(resError.code === 0) {


### PR DESCRIPTION
Opening a new pull request because the previous one was accidentally closed by me.
So, it seems like the current exile.js doesn't work when it gets an error. It always returns "Cannot read property length of undefined".
I added a JSON.parse() to parse the string, and it seems to work now.