### PR TITLE
Fix shout (Remove JSON.parse)

### DIFF
--- a/lib/group/shout.js
+++ b/lib/group/shout.js
@@ -28,7 +28,7 @@ function shoutOnGroup (group, shoutMessage, jar, xcsrf) {
         if (res.statusCode === 200) {
           resolve(res.body)
         } else {
-          const body = JSON.parse(res.body) || {}
+          const body = res.body || {}
           if (body.errors && body.errors.length > 0) {
             var errors = body.errors.map((e) => {
               return e.message

--- a/lib/group/shout.js
+++ b/lib/group/shout.js
@@ -26,7 +26,7 @@ function shoutOnGroup (group, shoutMessage, jar, xcsrf) {
     return http(httpOpt)
       .then(function (res) {
         if (res.statusCode === 200) {
-          resolve(JSON.parse(res.body))
+          resolve(res.body)
         } else {
           const body = JSON.parse(res.body) || {}
           if (body.errors && body.errors.length > 0) {


### PR DESCRIPTION
Not sure whats going on here, but shout has an unnessesary JSON.parse which is causing an error.
Res.body is already an object, not a string.

Simple fix!