### PR TITLE
Fix unnecessary JSON.parse at lines 29 & 31

### DIFF
--- a/lib/group/shout.js
+++ b/lib/group/shout.js
@@ -26,9 +26,9 @@ function shoutOnGroup (group, shoutMessage, jar, xcsrf) {
     return http(httpOpt)
       .then(function (res) {
         if (res.statusCode === 200) {
-          resolve(JSON.parse(res.body))
+          resolve(res.body)
         } else {
-          const body = JSON.parse(res.body) || {}
+          const body = res.body || {}
           if (body.errors && body.errors.length > 0) {
             var errors = body.errors.map((e) => {
               return e.message


### PR DESCRIPTION
The module throws an error when trying to shout.
```
Unhandled rejection SyntaxError: Unexpected token o in JSON at position 1
```
This can be fixed by simply removing the JSON.parse on lines 29 & 31.