### PR TITLE
Proposal: add setCookie & refreshCookie

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,5 @@ jspm_packages/
 .env
 
 \.vscode/
+
+.idea/

--- a/lib/user/cookieLogin.js
+++ b/lib/user/cookieLogin.js
@@ -8,6 +8,7 @@ var interval
 var day = 86400000
 exports.func = function (args) {
   // Run relog
+  console.warn('Noblox - The use of cookieLogin is deprecated: Please make use of the new methods setCookie & refreshCookie.')
   return relog(args.cookie)
     .then(function (r) {
       // Start interval

--- a/lib/user/setCookie.js
+++ b/lib/user/setCookie.js
@@ -1,0 +1,25 @@
+var options = require('../options.js')
+var getCurrentUser = require('../util/getCurrentUser.js').func
+
+exports.required = ['cookie']
+exports.optional = ['novalidate']
+
+exports.func = function (args) {
+  // verify it
+  if (!args.cookie.toLowerCase().includes('warning:-')) {
+    console.error('Warning: No Roblox warning detected in provided cookie. Ensure you include the entire .ROBLOSECURITY warning.')
+  }
+  if (args.validate === false) {
+    options.jar.session = args.cookie
+    return false
+  } else {
+    return getCurrentUser({ jar: { session: args.cookie } })
+      .then(function (res) {
+        options.jar.session = args.cookie
+        return res
+      }).catch(function (e) {
+        console.error('Failed to validate cookie: Are you sure the cookie is valid?\nEnsure you include the full cookie, including warning text.')
+        throw new Error(e)
+      })
+  }
+}

--- a/lib/util/refreshCookie.js
+++ b/lib/util/refreshCookie.js
@@ -1,0 +1,48 @@
+// Includes
+var options = require('../options.js')
+var getGeneralToken = require('./getGeneralToken.js').func
+var getVerification = require('./getVerification.js').func
+var http = require('./http.js').func
+// Args
+exports.required = []
+exports.optional = ['cookie']
+
+// Refreshes the internally stored cookie, or the cookie provided
+// Stores the new cookie & returns it
+function refreshCookie (cookie) {
+  if (cookie) {
+    options.jar.session = cookie
+  }
+  return getVerification({ url: 'https://www.roblox.com/my/account#!/security' })
+    .then((ver) => {
+      if (!ver.header) throw new Error('Failed to refresh - Invalid or expired cookie.')
+      return getGeneralToken({}).then((token) => {
+        return http({
+          url: 'https://www.roblox.com/authentication/signoutfromallsessionsandreauthenticate',
+          options: {
+            method: 'POST',
+            resolveWithFullResponse: true,
+            verification: ver.header,
+            jar: null,
+            headers: {
+              'X-CSRF-TOKEN': token
+            },
+            form: {
+              __RequestVerificationToken: ver.inputs.__RequestVerificationToken
+            }
+          }
+        }).then((res) => {
+          var cookies = res.headers['set-cookie']
+          if (cookies) {
+            const cookie = cookies.toString().match(/\.ROBLOSECURITY=(.*?);/)[1]
+            options.jar.session = cookie
+            return cookie
+          } else {
+            throw new Error('Failed to refresh cookie: None returned.')
+          }
+        })
+      })
+    })
+}
+
+module.exports = refreshCookie

--- a/lib/util/relog.js
+++ b/lib/util/relog.js
@@ -21,9 +21,9 @@ const relog = (cookie) => {
       if (!ver.header) console.log('Bad cookie.')
       return getGeneralToken({}).then((token) => {
         return http({
-          url: '//auth.roblox.com/v2/metadata',
+          url: 'https://www.roblox.com/authentication/signoutfromallsessionsandreauthenticate',
           options: {
-            method: 'GET',
+            method: 'POST',
             resolveWithFullResponse: true,
             verification: ver.header,
             jar: null,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "noblox.js",
-  "version": "4.5.6",
+  "version": "4.6.0",
   "description": "A Node.js wrapper for ROBLOX. (original from sentanos)",
   "main": "lib/index.js",
   "types": "typings/index.d.ts",


### PR DESCRIPTION
This PR would revert the changes made to relog to a state where they worked (though they log the user out of all sessions)

It:
- Deprecates cookieLogin
- Adds function setCookie
- Adds function refreshCookie
- Reverts relog.js

# setCookie
All setCookie does is store the provided cookie, and verify it (this is customisable through the novalidate argument)
It does not refresh the cookie.

# refreshCookie
Refreshes either a given cookie or the interally stored cookie, stores the newly generated cookie and returns it. This then places the responsibility for storing the cookie on it's user.
This information will need to be put in docs & readme, of course.


# Why?
See #114 
cookieLogin was intended as a temporary fix and it's been in use since March 2018.
I would say it's *bad* because libraries having unintended effects like this (and of course the creation of a file) makes them more difficult to use and it wreaks havoc with services like Glitch or Heroku. This PR means that these services are supported, provided the user creates their own storage mechanism for the refreshed cookie.

Another improvement about this is that we don't know *when* cookies expire, so the user can decide that themselves. I've personally had a lot of problems because the cookie file is stored relative to the file that runs it, not the library itself - and the cookie file creates an inherent security issue with many users unwittingly uploading their cookie file.