### PR TITLE
Added noblox.js.org for the documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ That's it!
 
 ## Documentation
 
-You can find the current noblox.js wiki with all API documentation [here](https://github.com/suufi/noblox.js/wiki). Keep in mind that all methods may not be documented. A majority of the new features that can be found in noblox.js are not in roblox-js. There will be new documentation coming in with v5.0.0. 
+You can find the current noblox.js wiki with all API documentation [here](https://noblox.js.org/). Keep in mind that all methods may not be documented. A majority of the new features that can be found in noblox.js are not in roblox-js. There will be new documentation coming in with v5.0.0. 
 
 ## Making use of new login workaround
 > Note, as of v4.6.0 The way you login to Noblox has changed significantly.


### PR DESCRIPTION
The current link is linking to the github wiki, documentation is located here: https://noblox.js.org/.

This may have been intentional, if so, just close it.