### PR TITLE
Add "get transactions" endpoints & update getPlayers

### DIFF
--- a/lib/group/getGroupTransactions.js
+++ b/lib/group/getGroupTransactions.js
@@ -1,0 +1,47 @@
+var http = require('../util/http.js').func
+var getGeneralToken = require('../util/getGeneralToken.js').func
+
+exports.required = ['group']
+exports.optional = ['transactionType', 'limit', 'cursor', 'jar']
+
+function getTransactions (group, transactionType, limit, cursor, jar, xcsrf) {
+  return new Promise((resolve, reject) => {
+    var httpOpt = {
+      url: `https://economy.roblox.com/v1/groups/${group}/transactions?limit=${limit}&transactionType=${transactionType}&cursor=${cursor}`,
+      options: {
+        method: 'GET',
+        resolveWithFullResponse: true,
+        jar: jar,
+        headers: {
+          'X-CSRF-TOKEN': xcsrf
+        }
+      }
+    }
+
+    return http(httpOpt)
+      .then(function (res) {
+        const responseData = JSON.parse(res.body)
+        if (res.statusCode !== 200) {
+          let error = 'An unknown error has occurred.'
+          if (responseData && responseData.errors) {
+            error = responseData.errors.map((e) => e.message).join('\n')
+          }
+          reject(new Error(error))
+        } else {
+          resolve(responseData)
+        }
+      })
+  })
+}
+
+// Define
+exports.func = function (args) {
+  const jar = args.jar
+  const transactionType = args.transactionType || 'Sale'
+  const limit = args.limit || 100
+  const cursor = args.cursor || ''
+  return getGeneralToken({ jar: jar })
+    .then(function (xcsrf) {
+      return getTransactions(args.group, transactionType, limit, cursor, xcsrf)
+    })
+}

--- a/lib/group/getPlayers.js
+++ b/lib/group/getPlayers.js
@@ -1,70 +1,103 @@
 // Includes
-const request = require('request')
+var http = require('../util/http.js').func
+var getGeneralToken = require('../util/getGeneralToken.js').func
 
 // Args
 exports.required = ['group', ['roleset']]
+exports.optional = ['sortOrder', 'limit', 'cursor', 'jar']
 
-function getPlayerData (groupId, roleId, pageCursor, currentPlayers) {
-  if (!pageCursor) pageCursor = ''
-  if (!currentPlayers) currentPlayers = []
-
+// Define
+function getPlayersInRoleOnPage (jar, token, group, rolesetId, sortOrder, limit, cursor) {
   return new Promise((resolve, reject) => {
-    request.get({
-      url: `https://groups.roblox.com/v1/groups/${groupId}/roles/${roleId}/users?cursor=${pageCursor}&limit=100&sortOrder=Desc`,
-      json: true
-    }, (err, res, body) => {
-      if (err) return reject(err)
-      if (res.statusCode !== 200) return reject(new Error(res.statusCode + ' : ' + res.statusMessage))
-
-      var nextPageCursor = body.nextPageCursor
-      var dataArray = body.data
-
-      if (!dataArray) return reject(new Error('Error while retreiving players!'))
-
-      if (nextPageCursor === null) {
-        if (dataArray.length > 0) {
-          currentPlayers = currentPlayers.concat(dataArray)
-        }
-        return resolve(currentPlayers)
+    var httpOpt = {
+      url: `//groups.roblox.com/v1/groups/${group}/roles/${rolesetId}/users?cursor=${cursor}&limit=${limit}&sortOrder=${sortOrder}`,
+      options: {
+        method: 'GET',
+        jar: jar,
+        headers: {
+          'X-CSRF-TOKEN': token
+        },
+        resolveWithFullResponse: true
       }
-
-      currentPlayers = currentPlayers.concat(dataArray)
-      getPlayerData(groupId, roleId, nextPageCursor, currentPlayers).then(function (newCurrentPlayers) {
-        return resolve(newCurrentPlayers)
+    }
+    return http(httpOpt)
+      .then(function (res) {
+        if (res.statusCode === 200) {
+          resolve(JSON.parse(res.body))
+        } else {
+          const body = JSON.parse(res.body) || {}
+          if (body.errors && body.errors.length > 0) {
+            var errors = body.errors.map((e) => {
+              return e.message
+            })
+            reject(new Error(`${res.statusCode} ${errors.join(', ')}`))
+          }
+        }
       })
-    })
   })
 }
 
-function getPlayers (groupId, rolesetIds, pageCursor, currentPlayers) {
+function getPlayersInRole (jar, token, group, rolesetId, sortOrder, limit, cursor, currentPlayers) {
   return new Promise((resolve, reject) => {
-    if (!pageCursor) pageCursor = ''
-    currentPlayers = []
+    console.log(rolesetId)
+    if (!currentPlayers) currentPlayers = []
 
-    for (var i = 0; i < rolesetIds.length; i++) {
-      try {
-        throw i
-      } catch (ii) {
-        getPlayerData(groupId, rolesetIds[ii]).then(newData => {
-          currentPlayers = currentPlayers.concat(newData)
-          if (rolesetIds[rolesetIds.length - 1] === rolesetIds[ii]) {
-            setTimeout(function () {
-              return resolve(currentPlayers)
-            }, 50)
-          };
-        })
-          .catch(error => {
-            reject(error)
+    getPlayersInRoleOnPage(jar, token, group, rolesetId, sortOrder, 100, cursor, currentPlayers)
+      .then(function(pageData) {
+        var nextPageCursor = pageData.nextPageCursor
+        var dataArray = pageData.data
+
+        if (!dataArray) return reject(new Error('Error while retreiving players!'))
+
+        currentPlayers = currentPlayers.concat(dataArray)
+
+        if (limit > 0 && currentPlayers.length >= limit) {
+          return resolve(currentPlayers.slice(0, limit))
+        } else if (nextPageCursor === null) {
+          return resolve(currentPlayers)
+        }
+
+        getPlayersInRole(jar, token, group, rolesetId, sortOrder, limit, nextPageCursor, currentPlayers)
+          .then(function (newCurrentPlayers) {
+            return resolve(newCurrentPlayers)
           })
+      })
+  })
+}
+
+function getPlayersInRoles (jar, token, group, rolesetIds, sortOrder, limit, cursor) {
+  return new Promise(async (resolve, reject) => {
+    var currentPlayers = []
+
+    for (i = 0; i < rolesetIds.length; i++) {
+      const rolesetId = rolesetIds[i]
+      const roleLimit = limit <= 0 ? limit : limit-currentPlayers.length
+
+      await getPlayersInRole(jar, token, group, rolesetId, sortOrder, roleLimit, cursor)
+        .then((newData) => {
+          currentPlayers = currentPlayers.concat(newData)
+        })
+        .catch((error) => {
+          reject(error)
+        })
+      
+      if (limit > 0 && currentPlayers.length >= limit) {
+        return resolve(currentPlayers)
       }
     }
+
+    return resolve(currentPlayers)
   })
 }
 
 exports.func = function (args) {
-  if (Array.isArray(args.roleset)) {
-    return getPlayers(args.group, args.roleset)
-  } else {
-    return getPlayers(args.group, [args.roleset])
-  }
+  const jar = args.jar
+  const rolesetIds = Array.isArray(args.roleset) ? args.roleset : [args.roleset]
+  const sortOrder = args.sortOrder || 'Desc'
+  const limit = args.limit || -1
+  const cursor = args.cursor || ''
+  return getGeneralToken({ jar: jar })
+    .then(function (xcsrf) {
+      return getPlayersInRoles(jar, xcsrf, args.group, rolesetIds, sortOrder, limit, cursor)
+    })
 }

--- a/lib/group/getPlayers.js
+++ b/lib/group/getPlayers.js
@@ -39,7 +39,6 @@ function getPlayersInRoleOnPage (jar, token, group, rolesetId, sortOrder, limit,
 
 function getPlayersInRole (jar, token, group, rolesetId, sortOrder, limit, cursor, currentPlayers) {
   return new Promise((resolve, reject) => {
-    console.log(rolesetId)
     if (!currentPlayers) currentPlayers = []
 
     getPlayersInRoleOnPage(jar, token, group, rolesetId, sortOrder, 100, cursor, currentPlayers)

--- a/lib/user/getUserTransactions.js
+++ b/lib/user/getUserTransactions.js
@@ -1,0 +1,47 @@
+var http = require('../util/http.js').func
+var getGeneralToken = require('../util/getGeneralToken.js').func
+
+exports.required = ['userId']
+exports.optional = ['transactionType', 'limit', 'cursor', 'jar']
+
+function getTransactions (userId, transactionType, limit, cursor, jar, xcsrf) {
+  return new Promise((resolve, reject) => {
+    var httpOpt = {
+      url: `https://economy.roblox.com/v1/users/${userId}/transactions?limit=${limit}&transactionType=${transactionType}&cursor=${cursor}`,
+      options: {
+        method: 'GET',
+        resolveWithFullResponse: true,
+        jar: jar,
+        headers: {
+          'X-CSRF-TOKEN': xcsrf
+        }
+      }
+    }
+
+    return http(httpOpt)
+      .then(function (res) {
+        const responseData = JSON.parse(res.body)
+        if (res.statusCode !== 200) {
+          let error = 'An unknown error has occurred.'
+          if (responseData && responseData.errors) {
+            error = responseData.errors.map((e) => e.message).join('\n')
+          }
+          reject(new Error(error))
+        } else {
+          resolve(responseData)
+        }
+      })
+  })
+}
+
+// Define
+exports.func = function (args) {
+  const jar = args.jar
+  const transactionType = args.transactionType || 'Sale'
+  const limit = args.limit || 100
+  const cursor = args.cursor || ''
+  return getGeneralToken({ jar: jar })
+    .then(function (xcsrf) {
+      return getTransactions(args.userId, transactionType, limit, cursor, xcsrf)
+    })
+}

--- a/lib/user/getUserTransactions.js
+++ b/lib/user/getUserTransactions.js
@@ -1,7 +1,7 @@
 var http = require('../util/http.js').func
 var getGeneralToken = require('../util/getGeneralToken.js').func
 
-exports.required = ['userId']
+exports.required = []
 exports.optional = ['transactionType', 'limit', 'cursor', 'jar']
 
 function getTransactions (userId, transactionType, limit, cursor, jar, xcsrf) {
@@ -42,6 +42,7 @@ exports.func = function (args) {
   const cursor = args.cursor || ''
   return getGeneralToken({ jar: jar })
     .then(function (xcsrf) {
-      return getTransactions(args.userId, transactionType, limit, cursor, xcsrf)
+      const currentUser = await getCurrentUser({ jar: jar })
+      return getTransactions(currentUser.UserID, transactionType, limit, cursor, xcsrf)
     })
 }

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1035,7 +1035,7 @@ declare module "noblox.js" {
     function getJoinRequests(group: number, sortOrder?: SortOrder, limit?: Limit, cursor?: string, jar?: CookieJar): Promise<GroupJoinRequestsPage>;
 
     /**
-     * Gets all (or up to limit) players in `group` with the number/array of `roleset`.
+     * Gets all (or up to limit when provided and greater than 0) players in `group` with the number/array of `roleset`.
      */
     function getPlayers(group: number, roleset: number[] | number, sortOrder?: SortOrder, limit?: number, jar?: CookieJar): Promise<GroupUser[]>;
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1022,7 +1022,7 @@ declare module "noblox.js" {
     /**
      * Gets the transaction history of the specified group.
      */
-    function getGroupTransactions(group: number, transactionType?: "" | "Sale" | "Purchase" | "AffiliateSale" | "DevEx" | "GroupPayout" | "AdImpressionPayout", limit?: Limit, cursor?: string, jar?: CookieJar): Promise<TransactionPage>;
+    function getGroupTransactions(group: number, transactionType?: "Sale" | "Purchase" | "AffiliateSale" | "DevEx" | "GroupPayout" | "AdImpressionPayout", limit?: Limit, cursor?: string, jar?: CookieJar): Promise<TransactionPage>;
 
     /**
      * Gets a brief overview of the specified group.
@@ -1168,7 +1168,7 @@ declare module "noblox.js" {
     /**
      * Gets the transaction history of the logged in user or of the user specified by the jar.
      */
-    function getUserTransactions(transactionType?: "" | "Sale" | "Purchase" | "AffiliateSale" | "DevEx" | "GroupPayout" | "AdImpressionPayout", limit?: Limit, cursor?: string, jar?: CookieJar): Promise<TransactionPage>;
+    function getUserTransactions(transactionType?: "Sale" | "Purchase" | "AffiliateSale" | "DevEx" | "GroupPayout" | "AdImpressionPayout", limit?: Limit, cursor?: string, jar?: CookieJar): Promise<TransactionPage>;
 
 
     /**

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -537,6 +537,42 @@ declare module "noblox.js" {
         previousPageCursor?: string;
     }
 
+    interface TransactionAgent
+    {
+        id: number;
+        type: string;
+        name: string;
+    }
+
+    interface TransactionDetails
+    {
+        id: number;
+        name: string;
+        type: string;
+    }
+
+    interface TransactionCurrency
+    {
+        amount: number;
+        type: string;
+    }
+
+    interface TransactionItem
+    {
+        created: Date;
+        isPending: boolean;
+        agent: TransactionAgent;
+        details?: TransactionDetails;
+        currency: TransactionCurrency;
+    }
+
+    interface TransactionPage
+    {
+        data: TransactionItem[];
+        nextPageCursor?: string;
+        previousPageCursor?: string;
+    }
+
     interface GroupJoinRequester 
     {
         userId: number;
@@ -984,6 +1020,11 @@ declare module "noblox.js" {
     function getAuditLog(group: number, actionType?: "" | "DeletePost" | "RemoveMember" | "AcceptJoinRequest" | "DeclineJoinRequest" | "PostStatus" | "ChangeRank" | "BuyAd" | "SendAllyRequest" | "CreateEnemy" | "AcceptAllyRequest" | "DeclineAllyRequest" | "DeleteAlly" | "DeleteEnemy" | "AddGroupPlace" | "RemoveGroupPlace" | "CreateItems" | "ConfigureItems" | "SpendGroupFunds" | "ChangeOwner" | "Delete" | "AdjustCurrencyAmounts" | "Abandon" | "Claim" | "Rename" | "ChangeDescription" | "InviteToClan" | "KickFromClan" | "CancelClanInvite" | "BuyClan" | "CreateGroupAsset" | "UpdateGroupAsset" | "ConfigureGroupAsset" | "RevertGroupAsset" | "CreateGroupDeveloperProduct" | "ConfigureGroupGame" | "Lock" | "Unlock" | "CreateGamePass" | "CreateBadge" | "ConfigureBadge" | "SavePlace" | "PublishPlace", userId?: number, sortOrder?: SortOrder, limit?: Limit, cursor?: string, jar?: CookieJar ): Promise<AuditPage>;
 
     /**
+     * Gets the transaction history of the specified group.
+     */
+    function getGroupTransactions(group: number, transactionType?: "" | "Sale" | "Purchase" | "AffiliateSale" | "DevEx" | "GroupPayout" | "AdImpressionPayout", limit?: Limit, cursor?: string, jar?: CookieJar): Promise<TransactionPage>;
+
+    /**
      * Gets a brief overview of the specified group.
      */
     function getGroup(groupId: number): Promise<Group>;
@@ -994,9 +1035,9 @@ declare module "noblox.js" {
     function getJoinRequests(group: number, sortOrder?: SortOrder, limit?: Limit, cursor?: string, jar?: CookieJar): Promise<GroupJoinRequestsPage>;
 
     /**
-     * Gets all players in `group` with the array `roleset`
+     * Gets all (or up to limit) players in `group` with the number/array of `roleset`.
      */
-    function getPlayers(group: number, roleset: number[], jar?: CookieJar): Promise<GroupUser[]>;
+    function getPlayers(group: number, roleset: number[] | number, sortOrder?: SortOrder, limit?: number, jar?: CookieJar): Promise<GroupUser[]>;
 
     /**
      * Gets `rank` of user with `userId` in `group` and caches according to settings.
@@ -1122,6 +1163,12 @@ declare module "noblox.js" {
      * Get the followers of a user (users who follow the specified person)
      */
     function getFollowers(userId: number, sortOrder?: SortOrder, limit?: Limit, cursor?: string, jar?: CookieJar): Promise<FollowersPage>;
+
+    
+    /**
+     * Gets the transaction history of the logged in user or of the user specified by the jar.
+     */
+    function getUserTransactions(transactionType?: "" | "Sale" | "Purchase" | "AffiliateSale" | "DevEx" | "GroupPayout" | "AdImpressionPayout", limit?: Limit, cursor?: string, jar?: CookieJar): Promise<TransactionPage>;
 
 
     /**


### PR DESCRIPTION
These endpoints return the list of items sold by a group or user. Will be useful for searching through sales to find or analyse them. The user endpoint can only be used for the currently authenticated user - I pointed out in the commit that it may be best to just use the userId of the said user.

May also be useful to have an onSale/onPurchase event for groups and user. If anyone wants to do that, go ahead. I might if I find time, but I don't specifically need these events at the moment.

Yes, this PR is pretty much just copypasta but I'd like access to these endpoints without using a fork of noblox.