### PR TITLE
Add getPlayerThumbnail

### DIFF
--- a/lib/user/getPlayerThumbnail.js
+++ b/lib/user/getPlayerThumbnail.js
@@ -1,0 +1,23 @@
+// Includes
+var http = require('../util/http.js').func
+
+// Args
+exports.required = ['userId', 'thumbnailType']
+
+// Define
+exports.func = function (args) {
+  return http({
+    url: 'https://www.roblox.com/' + args.thumbnailType + '-thumbnail/image?userId=' + args.userId '&width=' + args.size + '&height=' + args.size + '&format=png true',
+    options: {
+      resolveWithFullResponse: true,
+      followRedirect: true
+    }
+  })
+    .then(function (res) {
+      if (res.statusCode === 200) {
+        return res.body
+      } else {
+        throw new Error('User does not exist')
+      }
+    })
+}

--- a/lib/user/getPlayerThumbnail.js
+++ b/lib/user/getPlayerThumbnail.js
@@ -7,7 +7,7 @@ exports.required = ['userId', 'thumbnailType', 'size']
 // Define
 exports.func = function (args) {
   return http({
-    url: 'https://www.roblox.com/' + args.thumbnailType + '-thumbnail/image?userId=' + args.userId '&width=' + args.size + '&height=' + args.size + '&format=png true',
+    url: 'https://www.roblox.com/' + args.thumbnailType + '-thumbnail/image?userId=' + args.userId + '&width=' + args.size + '&height=' + args.size + '&format=png true',
     options: {
       resolveWithFullResponse: true,
       followRedirect: true

--- a/lib/user/getPlayerThumbnail.js
+++ b/lib/user/getPlayerThumbnail.js
@@ -2,7 +2,7 @@
 var http = require('../util/http.js').func
 
 // Args
-exports.required = ['userId', 'thumbnailType']
+exports.required = ['userId', 'thumbnailType', 'size']
 
 // Define
 exports.func = function (args) {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1147,6 +1147,11 @@ declare module "noblox.js" {
     function getPlayerInfo(userId: number): Promise<PlayerInfo>;
 
     /**
+     * Gets the thumbnail of a user.
+     */
+    function getPlayerThumbnail(userId: number): Promise<string>;
+
+    /**
      * Gets the presence statuses of the specified users
      */
     function getPresences(userIds: number[]): Promise<Presences>;


### PR DESCRIPTION
This endpoint will return a player's thumbnail when given the user-ID of the player, the thumbnail-type of the thumbnail, and the thumbnail size. This will be useful when displaying information about a user. I'd just like to access these endpoints without a fork. (This is my first pull request, so correct me if I'm wrong.)