### PR TITLE
Fix await in non-async function

### DIFF
--- a/lib/user/getUserTransactions.js
+++ b/lib/user/getUserTransactions.js
@@ -41,7 +41,7 @@ exports.func = function (args) {
   const limit = args.limit || 100
   const cursor = args.cursor || ''
   return getGeneralToken({ jar: jar })
-    .then(function (xcsrf) {
+    .then(async function (xcsrf) {
       const currentUser = await getCurrentUser({ jar: jar })
       return getTransactions(currentUser.UserID, transactionType, limit, cursor, xcsrf)
     })


### PR DESCRIPTION
I forgot to make the parent function async when awaiting on getCurrentUser. I made the modification without thought or testing, which was clearly a bad idea as it broke the entire thing!