### PR TITLE
v4.6.3: Fix getCurrentToken (Move to v2)

### DIFF
--- a/lib/user/getGroups.js
+++ b/lib/user/getGroups.js
@@ -7,16 +7,13 @@ exports.required = ['userId']
 exports.optional = ['jar']
 
 // Define
-function getGroups (jar, token, userId) {
+function getGroups (jar, userId) {
   return new Promise((resolve, reject) => {
     var httpOpt = {
       url: `//api.roblox.com/users/${userId}/groups`,
       options: {
         method: 'GET',
         jar: jar,
-        headers: {
-          'X-CSRF-TOKEN': token
-        },
         resolveWithFullResponse: true
       }
     }
@@ -39,8 +36,5 @@ function getGroups (jar, token, userId) {
 
 exports.func = function (args, senderUserId) {
   var jar = args.jar
-  return getGeneralToken({ jar: jar })
-    .then(function (xcsrf) {
-      return getGroups(jar, xcsrf, args.userId)
-    })
+  return getGroups(jar, args.userId);
 }

--- a/lib/user/getGroups.js
+++ b/lib/user/getGroups.js
@@ -1,6 +1,5 @@
 // Includes
 var http = require('../util/http.js').func
-var getGeneralToken = require('../util/getGeneralToken.js').func
 
 // Args
 exports.required = ['userId']
@@ -36,5 +35,5 @@ function getGroups (jar, userId) {
 
 exports.func = function (args, senderUserId) {
   var jar = args.jar
-  return getGroups(jar, args.userId);
+  return getGroups(jar, args.userId)
 }

--- a/lib/util/getGeneralToken.js
+++ b/lib/util/getGeneralToken.js
@@ -10,7 +10,7 @@ exports.optional = ['jar']
 function getGeneralToken (jar) {
   var httpOpt = {
     // This will never actually sign you out because an X-CSRF-TOKEN isn't provided, only received
-    url: '//auth.roblox.com/v1/logout', // REQUIRES https. Thanks for letting me know, ROBLOX...
+    url: '//auth.roblox.com/v2/logout', // REQUIRES https. Thanks for letting me know, ROBLOX...
     options: {
       resolveWithFullResponse: true,
       method: 'POST',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "noblox.js",
-  "version": "4.6.1",
+  "version": "4.6.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "noblox.js",
-  "version": "4.6.2",
+  "version": "4.6.3",
   "description": "A Node.js wrapper for ROBLOX. (original from sentanos)",
   "main": "lib/index.js",
   "types": "typings/index.d.ts",


### PR DESCRIPTION
See docs: https://auth.roblox.com/docs#!/v2
Tested with the following:
```js
const no = require("./noblox.js");
async function test () {
    await no.setCookie("Cookie");
    try {
        const t = await no.getGeneralToken()
        console.log(`Token, `, t);
    } catch (e) {
        console.error(`Failed: `, e);
    }
}
test();
```

Closes #163 
