### PR TITLE
Error for non-number 

### DIFF
--- a/lib/group/setRank.js
+++ b/lib/group/setRank.js
@@ -59,6 +59,9 @@ exports.func = function (args) {
     if (!rank) {
       opt.name = args.name
     } else {
+      if (typeof opt.rank !== 'number') {
+        throw new Error('setRank: Rank number must be a number')
+      }
       opt.rank = rank
     }
     return getRole(opt)


### PR DESCRIPTION
Adds a new error if you try to pass a rank number as a string.
I originally considered just converting it but you shouldn't be passing rank numbers as strings, so this just makes it more clear whats wrong.
Closes #175 