### PR TITLE
Fix circular dependency error

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -19,7 +19,7 @@ search(__dirname)
 
 for (const name in rbx) {
   const exporter = rbx[name]
-  if (exporter.func) {
+  if (exporter.hasOwnProperty("func")) {
     module.exports[name] = rbx.wrap.wrapExport(exporter.func, exporter.required || [], exporter.optional || [])
   } else {
     module.exports[name] = rbx[name]


### PR DESCRIPTION
This appears to fix the circular dependency error when utilizing Node.js v14.