### PR TITLE
Fix GetStatus typo

### DIFF
--- a/index.html
+++ b/index.html
@@ -1094,7 +1094,7 @@ Note: By default, setCookie will validate the cookie you provide by making a HTT
 </tr>
 </tbody></table>
 <h2 id='get-status'>Get Status</h2>
-<p>This function returns the status of a user. The blurb is the equivalent of the user&#39;s description on Roblox, not their status message.</p>
+<p>This function returns the status of a user. The status is the equivalent of the user&#39;s description on Roblox, not their blurb.</p>
 <pre class="highlight javascript tab-javascript"><code><span class="kr">const</span> <span class="nx">noblox</span> <span class="o">=</span> <span class="nx">require</span><span class="p">(</span><span class="s1">'noblox.js'</span><span class="p">);</span>
 
 <span class="p">...</span>

--- a/index.html
+++ b/index.html
@@ -1094,7 +1094,7 @@ Note: By default, setCookie will validate the cookie you provide by making a HTT
 </tr>
 </tbody></table>
 <h2 id='get-status'>Get Status</h2>
-<p>This function returns the blurb of a user. The blurb is the equivalent of the user&#39;s description on Roblox, not their status message.</p>
+<p>This function returns the status of a user. The blurb is the equivalent of the user&#39;s description on Roblox, not their status message.</p>
 <pre class="highlight javascript tab-javascript"><code><span class="kr">const</span> <span class="nx">noblox</span> <span class="o">=</span> <span class="nx">require</span><span class="p">(</span><span class="s1">'noblox.js'</span><span class="p">);</span>
 
 <span class="p">...</span>


### PR DESCRIPTION
The GetStatus documentation reads as:

```
Get Status

This function returns the blurb of a user. The blurb is the equivalent of the user's description on Roblox, not their status message.
```
It should say:

```
Get Status

This function returns the status of a user. The blurb is the equivalent of the user's description on Roblox, not their status message.
```