### PR TITLE
Update index.js to fix accessing of non-existent property

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -19,7 +19,7 @@ search(__dirname)
 
 for (const name in rbx) {
   const exporter = rbx[name]
-  if (exporter.hasOwnProperty("func")) {
+  if (Object.prototype.hasOwnProperty.call(exporter, 'func')) {
     module.exports[name] = rbx.wrap.wrapExport(exporter.func, exporter.required || [], exporter.optional || [])
   } else {
     module.exports[name] = rbx[name]

--- a/lib/index.js
+++ b/lib/index.js
@@ -19,7 +19,7 @@ search(__dirname)
 
 for (const name in rbx) {
   const exporter = rbx[name]
-  if (exporter.func) {
+  if (exporter.hasOwnProperty("func")) {
     module.exports[name] = rbx.wrap.wrapExport(exporter.func, exporter.required || [], exporter.optional || [])
   } else {
     module.exports[name] = rbx[name]


### PR DESCRIPTION
Fix bad reference that causes warnings when used with TypeScript

This isn't really important, since JS *manages*, but it's nice and will get rid of annoying warnings from my runtime.

The warning was: 

``(node:1572) Warning: Accessing non-existent property 'func' of module exports inside circular dependency``