### PR TITLE
Added configureGamePass() method.

### DIFF
--- a/lib/game/configureGamePass.js
+++ b/lib/game/configureGamePass.js
@@ -2,12 +2,38 @@
 const http = require('noblox.js/lib/util/http').func
 const getGeneralToken = require('noblox.js/lib/util/getGeneralToken').func
 
+// Docs
+/**
+ * Modifies an existing game pass.
+ * @category Game
+ * @alias configureGamePass
+ * @param {number} gamePassId - The id of the game pass.
+ * @param {string} name - The name of the game pass; skips name, description, and icon if set to "".
+ * @param {string=} description - The description of the game pass; description is updated when name is modified.
+ * @param {number|boolean=} price - The price of the game pass in Robux; sets to 'Off Sale' if 0, false, or a negative value; skips if true.
+ * @param {ReadStream=} icon - The read stream for the game pass icon being uploaded; .png, .jpg, .gif
+ * @returns {Promise<GamePassResponse>}
+ * @example const noblox = require("noblox.js")
+ * const fs = require("fs")
+ * // Login using your cookie
+ * noblox.configureGamePass(12345678, "Game Pass Title", "Game Pass Description", 1234, fs.createReadStream("./Image.png"))
+**/
+
 // Args
-exports.required = ['id', 'name']
-exports.optional = ['description', 'price', 'jar']
+exports.required = ['gamePassId', 'name']
+exports.optional = ['description', 'price', 'icon', 'jar']
 
 // Define
-function configure(jar, token, id, name, description, price) {
+function configure (jar, token, gamePassId, name, description, price, icon) {
+  const file = icon
+    ? {
+        value: icon,
+        options: {
+          filename: 'icon.png',
+          contentType: 'image/png'
+        }
+      }
+    : undefined
   const httpOpt = {
     url: '//www.roblox.com/game-pass/update',
     options: {
@@ -16,41 +42,49 @@ function configure(jar, token, id, name, description, price) {
       headers: {
         'X-CSRF-TOKEN': token
       },
-      json: {
-        id,
-        name,
-        description
+      resolveWithFullResponse: true,
+      formData: {
+        id: gamePassId,
+        name: name,
+        description: description,
+        file
       }
     }
   }
 
-  // Skip updating name and description if they are not provided.
-  if (!(name || description)) {
+  // Skip updating name and description if name is empty.
+  if (!name) {
     return {
-      gamepassId: id,
-      ...name,
-      ...description,
+      gamePassId,
       ...price
     }
   }
 
-  return http(httpOpt).then(function (json) {
+  return http(httpOpt).then(function (res) {
+    const json = JSON.parse(res.body)
     if (json.isValid) {
       return {
-        gamepassId: id,
+        gamePassId,
         name,
         description: description || '',
-        ...price
+        ...price,
+        iconChanged: !!file // Boolean Cast
       }
     } else {
-      // @TODO: Improve error messaging; ROBLOX provides little useful (HTML 403 instead of JSON) feedback on why a request may be considered "not valid", error prevention has been done as much as is practical.
-      throw new Error('An error occurred running configureGamepass.js; you likely are accessing a gamepass you do not have permission to edit, or are providing an illegal input.');
+      const priceComment = (typeof (price) === 'number') ? ` | NOTE: Price has successfully been changed to ${price}R.` : ''
+      if (res.statusCode === 403) {
+        throw new Error('You do not have permission to edit this game pass.' + priceComment)
+      } else if (json.error) {
+        throw new Error(json.error + priceComment) // 'The name or description contains inappropriate text.' or 'Text filtering service is unavailable at this time.'
+      } else {
+        throw new Error(`An unexpected error occurred with status code ${res.statusCode}.` + priceComment)
+      }
     }
   })
 }
 
 // Configuring the name/description and robux must be done in separate calls, albeit to the same end-point.
-function configureRobux(args) {
+function configureRobux (args) {
   const httpOpt = {
     url: '//www.roblox.com/game-pass/update',
     options: {
@@ -59,38 +93,53 @@ function configureRobux(args) {
       headers: {
         'X-CSRF-TOKEN': args.token
       },
+      resolveWithFullResponse: true,
       json: {
-        id: args.id,
+        id: args.gamePassId,
         price: Math.floor(args.price || 0), // Prevent Decimals
         isForSale: !!Math.max(args.price, 0) // Boolean Cast
       }
     }
   }
-  return http(httpOpt).then(function (json) {
-    if (json.isValid) {
+  return http(httpOpt).then(function (res) {
+    if (res.body.isValid) {
       // Passing price as an object, so they can be omitted if configureRobux is not run.
-      return configure(args.jar, args.token, args.id, args.name, args.description, {
-        price: Math.max(Math.floor(args.price || 0), 0),
-        isForSale: !!Math.max(args.price, 0)
-      })
+      return configure(
+        args.jar,
+        args.token,
+        args.gamePassId,
+        args.name,
+        args.description,
+        {
+          price: Math.max(Math.floor(args.price || 0), 0),
+          isForSale: !!Math.max(args.price, 0)
+        },
+        args.icon
+      )
     } else {
-      throw new Error('An error occurred running configureGamepass.js; you likely are accessing a gamepass you do not have permission to edit, or are providing an illegal input.');
+      if (res.statusCode === 403) {
+        throw new Error('You do not have permission to edit this game pass.')
+      } else if (res.body.error) {
+        throw new Error(res.body.error)
+      } else {
+        throw new Error(`An unexpected error occurred with status code ${res.statusCode}.`)
+      }
     }
   })
 }
 
-function runWithToken(args) {
+function runWithToken (args) {
   const jar = args.jar
   return getGeneralToken({
-      jar
-    })
+    jar
+  })
     .then(function (token) {
-      args.token = token;
+      args.token = token
       // Needs to catch falsy input of `false` and `0` as they should change the gamepass to offsale; price updating will be skipped if undefined.
       if (typeof (args.price) === 'boolean' || typeof (args.price) === 'number') {
-        return configureRobux(args);
+        return configureRobux(args)
       } else {
-        return configure(args.jar, args.token, args.id, args.name, args.description);
+        return configure(args.jar, args.token, args.gamePassId, args.name, args.description, undefined, args.icon)
       }
     })
 }

--- a/lib/game/configureGamePass.js
+++ b/lib/game/configureGamePass.js
@@ -1,6 +1,10 @@
 // Includes
-const http = require('noblox.js/lib/util/http').func
-const getGeneralToken = require('noblox.js/lib/util/getGeneralToken').func
+const http = require('../util/http').func
+const getGeneralToken = require('../util/getGeneralToken').func
+
+// Args
+exports.required = ['gamePassId', 'name']
+exports.optional = ['description', 'price', 'icon', 'jar']
 
 // Docs
 /**
@@ -17,81 +21,80 @@ const getGeneralToken = require('noblox.js/lib/util/getGeneralToken').func
  * const fs = require("fs")
  * // Login using your cookie
  * noblox.configureGamePass(12345678, "Game Pass Title", "Game Pass Description", 1234, fs.createReadStream("./Image.png"))
-**/
-
-// Args
-exports.required = ['gamePassId', 'name']
-exports.optional = ['description', 'price', 'icon', 'jar']
+ **/
 
 // Define
-function configure (jar, token, gamePassId, name, description, price, icon) {
-  const file = icon
-    ? {
+function configureGamePass (gamePassId, name, description, price, icon, jar, token) {
+  return new Promise((resolve, reject) => {
+    const file = icon
+      ? {
         value: icon,
         options: {
           filename: 'icon.png',
           contentType: 'image/png'
         }
       }
-    : undefined
-  const httpOpt = {
-    url: '//www.roblox.com/game-pass/update',
-    options: {
-      method: 'POST',
-      jar: jar,
-      headers: {
-        'X-CSRF-TOKEN': token
-      },
-      resolveWithFullResponse: true,
-      formData: {
-        id: gamePassId,
-        name: name,
-        description: description,
-        file
+      : undefined
+    const httpOpt = {
+      url: '//www.roblox.com/game-pass/update',
+      options: {
+        method: 'POST',
+        jar: jar,
+        headers: {
+          'X-CSRF-TOKEN': token,
+          'Content-Type': 'multipart/form-data; boundary=----WebKitFormBoundaryKMFaNaAn4j7XeMO'
+        },
+        resolveWithFullResponse: true,
+        formData: {
+          id: gamePassId,
+          name,
+          description,
+          file
+        }
       }
     }
-  }
 
-  // Skip updating name and description if name is empty.
-  if (!name) {
-    return {
-      gamePassId,
-      ...price
-    }
-  }
-
-  return http(httpOpt).then(function (res) {
-    const json = JSON.parse(res.body)
-    if (json.isValid) {
-      return {
+    // Skip updating name and description if name is empty.
+    if (!name) {
+      resolve({
         gamePassId,
-        name,
-        description: description || '',
-        ...price,
-        iconChanged: !!file // Boolean Cast
-      }
-    } else {
-      const priceComment = (typeof (price) === 'number') ? ` | NOTE: Price has successfully been changed to ${price}R.` : ''
-      if (res.statusCode === 403) {
-        throw new Error('You do not have permission to edit this game pass.' + priceComment)
-      } else if (json.error) {
-        throw new Error(json.error + priceComment) // 'The name or description contains inappropriate text.' or 'Text filtering service is unavailable at this time.'
-      } else {
-        throw new Error(`An unexpected error occurred with status code ${res.statusCode}.` + priceComment)
-      }
+        ...price
+      })
     }
+
+    return http(httpOpt).then(function (res) {
+      const json = JSON.parse(res.body)
+      if (json.isValid) {
+        resolve({
+          gamePassId,
+          name,
+          description: description || '',
+          ...price,
+          iconChanged: !!file // Boolean Cast
+        })
+      } else {
+        const priceComment = (typeof (price) === 'number') ? ` | NOTE: Price has successfully been changed to ${price}R.` : ''
+        if (res.statusCode === 403) {
+          reject(new Error(`You do not have permission to edit this game pass.${priceComment}`))
+        } else if (json.error) {
+          reject(new Error(json.error + priceComment)) // 'The name or description contains inappropriate text.' or 'Text filtering service is unavailable at this time.'
+        } else {
+          reject(new Error(`An unexpected error occurred with status code ${res.statusCode}.${priceComment}`))
+        }
+      }
+    })
   })
 }
 
-// Configuring the name/description and robux must be done in separate calls, albeit to the same end-point.
-function configureRobux (args) {
+// Configuring the name/description and Robux must be done in separate calls, albeit to the same end-point.
+function configureRobux (args, token) {
   const httpOpt = {
     url: '//www.roblox.com/game-pass/update',
     options: {
       method: 'POST',
       jar: args.jar,
       headers: {
-        'X-CSRF-TOKEN': args.token
+        'X-CSRF-TOKEN': token
       },
       resolveWithFullResponse: true,
       json: {
@@ -104,9 +107,7 @@ function configureRobux (args) {
   return http(httpOpt).then(function (res) {
     if (res.body.isValid) {
       // Passing price as an object, so they can be omitted if configureRobux is not run.
-      return configure(
-        args.jar,
-        args.token,
+      return configureGamePass(
         args.gamePassId,
         args.name,
         args.description,
@@ -114,7 +115,9 @@ function configureRobux (args) {
           price: Math.max(Math.floor(args.price || 0), 0),
           isForSale: !!Math.max(args.price, 0)
         },
-        args.icon
+        args.icon,
+        args.jar,
+        token
       )
     } else {
       if (res.statusCode === 403) {
@@ -128,22 +131,17 @@ function configureRobux (args) {
   })
 }
 
-function runWithToken (args) {
+exports.func = function (args) {
   const jar = args.jar
+
   return getGeneralToken({
     jar
+  }).then(function (token) {
+    // Needs to catch falsy input of `false` and `0` as they should change the gamepass to offsale; price updating will be skipped if undefined.
+    if (typeof (args.price) === 'boolean' || typeof (args.price) === 'number') {
+      return configureRobux(args, token)
+    } else {
+      return configureGamePass(args.gamePassId, args.name, args.description, undefined, args.icon, jar, token)
+    }
   })
-    .then(function (token) {
-      args.token = token
-      // Needs to catch falsy input of `false` and `0` as they should change the gamepass to offsale; price updating will be skipped if undefined.
-      if (typeof (args.price) === 'boolean' || typeof (args.price) === 'number') {
-        return configureRobux(args)
-      } else {
-        return configure(args.jar, args.token, args.gamePassId, args.name, args.description, undefined, args.icon)
-      }
-    })
-}
-
-exports.func = function (args) {
-  return runWithToken(args)
 }

--- a/lib/game/configureGamePass.js
+++ b/lib/game/configureGamePass.js
@@ -1,0 +1,100 @@
+// Includes
+const http = require('noblox.js/lib/util/http').func
+const getGeneralToken = require('noblox.js/lib/util/getGeneralToken').func
+
+// Args
+exports.required = ['id', 'name']
+exports.optional = ['description', 'price', 'jar']
+
+// Define
+function configure(jar, token, id, name, description, price) {
+  const httpOpt = {
+    url: '//www.roblox.com/game-pass/update',
+    options: {
+      method: 'POST',
+      jar: jar,
+      headers: {
+        'X-CSRF-TOKEN': token
+      },
+      json: {
+        id,
+        name,
+        description
+      }
+    }
+  }
+
+  // Skip updating name and description if they are not provided.
+  if (!(name || description)) {
+    return {
+      gamepassId: id,
+      ...name,
+      ...description,
+      ...price
+    }
+  }
+
+  return http(httpOpt).then(function (json) {
+    if (json.isValid) {
+      return {
+        gamepassId: id,
+        name,
+        description: description || '',
+        ...price
+      }
+    } else {
+      // @TODO: Improve error messaging; ROBLOX provides little useful (HTML 403 instead of JSON) feedback on why a request may be considered "not valid", error prevention has been done as much as is practical.
+      throw new Error('An error occurred running configureGamepass.js; you likely are accessing a gamepass you do not have permission to edit, or are providing an illegal input.');
+    }
+  })
+}
+
+// Configuring the name/description and robux must be done in separate calls, albeit to the same end-point.
+function configureRobux(args) {
+  const httpOpt = {
+    url: '//www.roblox.com/game-pass/update',
+    options: {
+      method: 'POST',
+      jar: args.jar,
+      headers: {
+        'X-CSRF-TOKEN': args.token
+      },
+      json: {
+        id: args.id,
+        price: Math.floor(args.price || 0), // Prevent Decimals
+        isForSale: !!Math.max(args.price, 0) // Boolean Cast
+      }
+    }
+  }
+  return http(httpOpt).then(function (json) {
+    if (json.isValid) {
+      // Passing price as an object, so they can be omitted if configureRobux is not run.
+      return configure(args.jar, args.token, args.id, args.name, args.description, {
+        price: Math.max(Math.floor(args.price || 0), 0),
+        isForSale: !!Math.max(args.price, 0)
+      })
+    } else {
+      throw new Error('An error occurred running configureGamepass.js; you likely are accessing a gamepass you do not have permission to edit, or are providing an illegal input.');
+    }
+  })
+}
+
+function runWithToken(args) {
+  const jar = args.jar
+  return getGeneralToken({
+      jar
+    })
+    .then(function (token) {
+      args.token = token;
+      // Needs to catch falsy input of `false` and `0` as they should change the gamepass to offsale; price updating will be skipped if undefined.
+      if (typeof (args.price) === 'boolean' || typeof (args.price) === 'number') {
+        return configureRobux(args);
+      } else {
+        return configure(args.jar, args.token, args.id, args.name, args.description);
+      }
+    })
+}
+
+exports.func = function (args) {
+  return runWithToken(args)
+}

--- a/lib/game/configureGamePass.js
+++ b/lib/game/configureGamePass.js
@@ -28,12 +28,12 @@ function configureGamePass (gamePassId, name, description, price, icon, jar, tok
   return new Promise((resolve, reject) => {
     const file = icon
       ? {
-        value: icon,
-        options: {
-          filename: 'icon.png',
-          contentType: 'image/png'
+          value: icon,
+          options: {
+            filename: 'icon.png',
+            contentType: 'image/png'
+          }
         }
-      }
       : undefined
     const httpOpt = {
       url: '//www.roblox.com/game-pass/update',

--- a/test/game.test.js
+++ b/test/game.test.js
@@ -1,4 +1,4 @@
-const { addDeveloperProduct, checkDeveloperProductName, getDeveloperProducts, getGameBadges, getGameInstances, getPlaceInfo, updateDeveloperProduct, setCookie } = require('../lib')
+const { addDeveloperProduct, checkDeveloperProductName, configureGamePass, getDeveloperProducts, getGameBadges, getGameInstances, getPlaceInfo, updateDeveloperProduct, setCookie } = require('../lib')
 
 beforeAll(() => {
   return new Promise(resolve => {
@@ -30,6 +30,20 @@ describe('Game Methods', () => {
       return expect(res).toMatchObject({
         Success: expect.any(Boolean),
         Message: expect.any(String)
+      })
+    })
+  })
+
+  it('configureGamePass() should configure a game pass', () => {
+    const randomString = Date.now().toString().substr(-2)
+    return configureGamePass(13925030, `name${randomString}`, `random description`, parseInt(randomString)).then((res) => {
+      return expect(res).toMatchObject({
+        gamePassId: 13925030,
+        name: `name${randomString}`,
+        description: `random description`,
+        price: parseInt(randomString),
+        isForSale: true,
+        iconChanged: false
       })
     })
   })

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -449,7 +449,7 @@ declare module "noblox.js" {
         gamePassId: number,
         name?: string,
         description?: string,
-        price?: number | null,
+        price?: number,
         isForSale?: boolean,
         iconChanged?: boolean
     }

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1053,6 +1053,8 @@ declare module "noblox.js" {
 
     /**
      * Configures an item (shirt, pants, decal, etc.) with the id `id` to have `name` and `description`. If `enableComments` is true comments will be allowed and if `sellForRobux` is set it will be put on sale for that amount of robux.
+     *
+     * NOTE: Use `configureGamePass()` for Game Passes.
      */
     function configureItem(id: number, name: string, description: string, enableComments?: boolean, sellForRobux?: boolean, genreSelection?: number, jar?: CookieJar): Promise<void>;
 
@@ -1199,6 +1201,14 @@ declare module "noblox.js" {
     function getDeveloperProducts(placeId: number, page: number, jar?: CookieJar): Promise<DeveloperProductsResult>;
 
     function updateDeveloperProduct(universeId: number, productId: number, name: string, priceInRobux: number, description?: string, jar?: CookieJar): Promise<DeveloperProductUpdateResult>;
+
+    /**
+     * Configures a gamepass with the id `gamepassId` to have a `name` and `description`, and sets the `price` in Robux. If both `name` and `description` are empty, only `price` is changed. Setting `price` to false, 0, or a negative value will place the gamepass off-sale.
+     * Returns `gamepassId` with the changed attributes.
+     * 
+     * NOTE: Updating `name` will affect `description`: you must 'refresh' `description` with each `name` update, or `description` will be cleared.
+     */
+    function configureGamePass(gamepassId: number, name: string, description?: string, price?: number | boolean, jar?: CookieJar): Promise<GamepassInfo>;
 
     /// Group
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -444,6 +444,16 @@ declare module "noblox.js" {
         TotalCollectionSize: number;
     }
 
+    interface GamePassResponse
+    {
+        gamePassId: number,
+        name?: string,
+        description?: string,
+        price?: number | null,
+        isForSale?: boolean,
+        iconChanged?: boolean
+    }
+
     interface PlaceInformation {
         AssetId: number;
         Name: string;
@@ -1203,12 +1213,13 @@ declare module "noblox.js" {
     function updateDeveloperProduct(universeId: number, productId: number, name: string, priceInRobux: number, description?: string, jar?: CookieJar): Promise<DeveloperProductUpdateResult>;
 
     /**
-     * Configures a gamepass with the id `gamepassId` to have a `name` and `description`, and sets the `price` in Robux. If both `name` and `description` are empty, only `price` is changed. Setting `price` to false, 0, or a negative value will place the gamepass off-sale.
-     * Returns `gamepassId` with the changed attributes.
+     * Configures a game pass with the id `gamePassId` to have a `name`, `description`, `price` in Robux, and `icon` image. If `name` is an empty string, only `price` is changed. Setting `price` to false, 0, or a negative value will place the gamepass off-sale.
+     * Returns a `GamePassResponse` with the changed attributes.
      * 
-     * NOTE: Updating `name` will affect `description`: you must 'refresh' `description` with each `name` update, or `description` will be cleared.
+     * NOTE: Updating `name` will affect `description`: you must repeat `description` with each `name` update, or `description` will be cleared.
      */
-    function configureGamePass(gamepassId: number, name: string, description?: string, price?: number | boolean, jar?: CookieJar): Promise<GamepassInfo>;
+    
+    function configureGamePass(gamePassId: number, name: string, description?: string, price?: number | boolean, icon?: string | stream.Stream, jar?: CookieJar): Promise<GamePassResponse>;
 
     /// Group
 

--- a/typings/jsDocs.ts
+++ b/typings/jsDocs.ts
@@ -556,6 +556,18 @@ type GameInstances = {
 
 /**
  * @typedef
+ */
+type GamePassResponse = {
+    gamePassId: number,
+    name?: string,
+    description?: string,
+    price?: number,
+    isForSale?: boolean,
+    iconChanged?: boolean
+}
+
+/**
+ * @typedef
 */
 type PlaceInformation = {
     AssetId: number;


### PR DESCRIPTION
I added a `configureGamePass()` method since the existing `configureItem()` is incompatible with GamePassIDs, as GamePassIDs can overlap AssetIDs. 

I tried to maintain parity with the structure used by `configureItem()` as much as possible, but the `www.roblox.com/game-pass/update/` endpoint forces weird behavior as it is seemingly designed for the web browser rather than a REST API.

My method takes the parameters:
```js
configureGamePass(gamepassId: number, name: string, description?: string, price?: number | boolean, jar?: CookieJar)
```

Roblox breaks the dashboard up into `name`/`description` and `price`/`isForSale`; you cannot change both groups with a singular API call, ergo the WET code that makes up to two API calls; unnecessary calls are automatically dropped. Passing `0`, `false` or a negative value to `price` will make the game pass go off sale.

I have noted the quirk in `index.d.ts` that passing only a `name` updates both the `name` and `description`; thus purging the old description.

---

Since this uses the `www.` subdomain, errors display via an HTML page rather than a JSON response. I think I have any type errors covered and have left an intentionally vague error message for bad GamePassIDs throw call.

**TODO:** Currently this method doesn't support changing the icon. I couldn't justify the time investment for the niche within the niche use-case as this method already supports my needs and I'd have to fuss with ROBLOX moderation while testing.
