### PR TITLE
Update getOwnership() to support game passes, badges, and bundles.

### DIFF
--- a/lib/user/getMessages.js
+++ b/lib/user/getMessages.js
@@ -13,7 +13,7 @@ exports.optional = ['pageNumber', 'pageSize', 'messageTab', 'jar']
  * @alias getMessages
  * @param {number=} [pageNumber=0] - The number of the current page.
  * @param {number=} [pageSize=25] - The size of the current page.
- * @param {('Inbox' | 'Sent' | 'Archive')=} [messageTab='Inbox'] - The tab of the messages being fetched (Inbox, Sent, Archive)
+ * @param {("Inbox" | "Sent" | "Archive")=} [messageTab=Inbox] - The tab of the messages being fetched (Inbox, Sent, Archive)
  * @returns {Promise<PrivateMessagesPage>}
  * @example const noblox = require("noblox.js")
  * // Login using your cookie

--- a/lib/user/getOwnership.js
+++ b/lib/user/getOwnership.js
@@ -2,8 +2,8 @@
 const http = require('../util/http.js').func
 
 // Args
-exports.required = ['userId', 'assetId']
-exports.optional = []
+exports.required = ['userId', 'itemTargetId']
+exports.optional = ['itemType']
 
 // Docs
 /**
@@ -11,17 +11,18 @@ exports.optional = []
  * @category User
  * @alias getOwnership
  * @param {number} userId - The id of the user whose ownership is being checked.
- * @param {number} assetId - The id of the asset.
+ * @param {number} itemTargetId - The id of the item.
+ * @param {("Asset" | "GamePass" | "Badge" | "Bundle")=} [itemType=Asset] - The type of item in question (Asset, GamePass, Badge, Bundle)
  * @returns {Promise<boolean>}
  * @example const noblox = require("noblox.js")
- * let ownership = await noblox.getOwnership(123456, 234567)
+ * let ownership = await noblox.getOwnership(123456, 234567, "GamePass")
 **/
 
 // Define
-function getOwnership (userId, assetId) {
+function getOwnership (userId, itemTargetId, itemType) {
   return new Promise((resolve, reject) => {
     const httpOpt = {
-      url: `//api.roblox.com/ownership/hasasset?userId=${userId}&assetId=${assetId}`,
+      url: `//inventory.roblox.com/v1/users/${userId}/items/${itemType}/${itemTargetId}`,
       options: {
         method: 'GET',
         resolveWithFullResponse: true
@@ -30,7 +31,8 @@ function getOwnership (userId, assetId) {
     return http(httpOpt)
       .then(function (res) {
         if (res.statusCode === 200) {
-          resolve(res.body === 'true')
+          const body = JSON.parse(res.body)
+          resolve(body.data.length > 0)
         } else {
           const body = JSON.parse(res.body) || {}
           if (body.errors && body.errors.length > 0) {
@@ -47,5 +49,6 @@ function getOwnership (userId, assetId) {
 }
 
 exports.func = function (args) {
-  return getOwnership(args.userId, args.assetId)
+  const itemType = args.itemType || 'Asset'
+  return getOwnership(args.userId, args.itemTargetId, itemType)
 }

--- a/test/user.test.js
+++ b/test/user.test.js
@@ -250,8 +250,26 @@ describe('User Methods', () => {
     })
   })
 
-  it('getOwnership() returns if a player owns the specified asset', () => {
+  it('getOwnership() [ASSET] returns if a player owns the specified asset', () => {
     return getOwnership(55549140, 1900419889).then((res) => {
+      return expect(res).toBe(true)
+    })
+  })
+
+  it('getOwnership() [GAMEPASS] returns if a player owns the specified game pass', () => {
+    return getOwnership(55549140, 1537467, 'GamePass').then((res) => {
+      return expect(res).toBe(true)
+    })
+  })
+
+  it('getOwnership() [BADGE] returns if a player owns the specified badge', () => {
+    return getOwnership(55549140, 176332932, 'Badge').then((res) => {
+      return expect(res).toBe(true)
+    })
+  })
+
+  it('getOwnership() [BUNDLE] returns if a player owns the specified bundle', () => {
+    return getOwnership(55549140, 79, 'Bundle').then((res) => {
       return expect(res).toBe(true)
     })
   })

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1277,7 +1277,7 @@ declare module "noblox.js" {
     function updateDeveloperProduct(universeId: number, productId: number, name: string, priceInRobux: number, description?: string, jar?: CookieJar): Promise<DeveloperProductUpdateResult>;
 
     /**
-     * Configures a game pass with the id `gamePassId` to have a `name`, `description`, `price` in Robux, and `icon` image. If `name` is an empty string, only `price` is changed. Setting `price` to false, 0, or a negative value will place the gamepass off-sale.
+     * Configures a game pass with the id `gamePassId` to have a `name`, `description`, `price` in Robux, and `icon` image. If `name` is an empty string, only `price` is changed. Setting `price` to false, 0, or a negative value will place the game pass off-sale.
      * Returns a `GamePassResponse` with the changed attributes.
      * 
      * NOTE: Updating `name` will affect `description`: you must repeat `description` with each `name` update, or `description` will be cleared.
@@ -1528,13 +1528,12 @@ declare module "noblox.js" {
     /**
      * Gets the messages of the logged in user or of the user specified by the jar. Returns by newest to oldest messages.
      */
-    function getMessages(pageNumber?: number, pageSize?: number, messageTab?: 'Archive' | 'Inbox' | 'Sent', jar?: CookieJar): Promise<PrivateMessagesPage>;
-
+    function getMessages(pageNumber?: number, pageSize?: number, messageTab?: "Archive" | "Inbox" | "Sent", jar?: CookieJar): Promise<PrivateMessagesPage>;
 
     /**
      * Returns whether a user owns an asset or not
      */
-    function getOwnership(userId: number, assetId: number): Promise<boolean>;
+    function getOwnership(userId: number, itemTargetId: number, itemType?: "Asset" | "GamePass" | "Badge" | "Bundle"): Promise<boolean>;
 
     /**
      * Gets the badges of a user.


### PR DESCRIPTION
Currently `getOwnership()` only supports assetIDs; I changed the endpoint being used so it now supports an optional parameter for the alternative item types: `GamePass`, `Badge`, and `Bundle`.

All changes should maintain backwards compatibility. I also added three unit tests using [`Qxest`](https://www.roblox.com/users/55549140/profile) which covers the three additional ID types.

---

Minor documentation hotfixes to `getMessages()` and `configureGamePass()` for parity are included as well.
