### PR TITLE
Use X-CSRF-Token to reflect endpoint change

### DIFF
--- a/lib/asset/uploadModel.js
+++ b/lib/asset/uploadModel.js
@@ -1,5 +1,6 @@
 // Includes
 const http = require('../util/http.js').func
+const getGeneralToken = require('../util/getGeneralToken').func
 
 // Args
 exports.required = ['data']
@@ -32,7 +33,7 @@ exports.optional = ['itemOptions', 'asset', 'jar']
 **/
 
 // Define
-function upload (jar, data, itemOptions, asset) {
+function upload (data, itemOptions, asset, jar, token) {
   const httpOpt = {
     url: '//data.roblox.com/Data/Upload.ashx?json=1&assetid=' + (asset || 0),
     options: {
@@ -41,6 +42,7 @@ function upload (jar, data, itemOptions, asset) {
       jar: jar,
       body: data,
       headers: {
+        'X-CSRF-TOKEN': token,
         'Content-Type': 'application/xml'
       }
     }
@@ -79,5 +81,10 @@ function upload (jar, data, itemOptions, asset) {
 }
 
 exports.func = function (args) {
-  return upload(args.jar, args.data, args.itemOptions, args.asset)
+  const jar = args.jar
+  return getGeneralToken({
+    jar
+  }).then(function (token) {
+    return upload(args.data, args.itemOptions, args.asset, args.jar, token)
+  })
 }


### PR DESCRIPTION
A fix regarding the `uploadModel()` endpoint to address the new X-CSRF-Token requirement [per the DevForum announcement](https://devforum.roblox.com/t/changes-to-the-data-upload-ashx-endpoint-x-csrf-token-validation/1021830).