### PR TITLE
Remove post method from typings

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1315,11 +1315,6 @@ declare module "noblox.js" {
     function leaveGroup(group: number, jar?: CookieJar): Promise<void>;
 
     /**
-     * Posts message `message` on the group wall with groupId `group`.
-     */
-    function post(group: number, message: string, jar?: CookieJar): Promise<void>;
-
-    /**
      * Alias of `changeRank(group, target, 1)`.
      */
     function promote(group: number, target: number, jar?: CookieJar): Promise<ChangeRankResult>;


### PR DESCRIPTION
The post method was removed in 4.6.1 due to captchas. It is still in the typings.