### PR TITLE
Added getPremium() function

### DIFF
--- a/lib/user/getPremium.js
+++ b/lib/user/getPremium.js
@@ -18,34 +18,34 @@ exports.optional = ['jar']
  **/
 
 // Define
-function getPremium(jar, userId) {
-    return new Promise((resolve, reject) => {
-        const httpOpt = {
-            url: `https://premiumfeatures.roblox.com/v1/users/${userId}/validate-membership`,
-            options: {
-                method: 'GET',
-                jar: jar,
-                resolveWithFullResponse: true
-            }
-        }
-        return http(httpOpt)
-            .then(function(res) {
-                if (res.statusCode === 200) {
-                    resolve(res.body == 'true')
-                } else {
-                    const body = JSON.parse(res.body) || {}
-                    if (body.errors && body.errors.length > 0) {
-                        const errors = body.errors.map((e) => {
-                            return e.message
-                        })
-                        reject(new Error(`${res.statusCode} ${errors.join(', ')}`))
-                    }
-                }
+function getPremium (jar, userId) {
+  return new Promise((resolve, reject) => {
+    const httpOpt = {
+      url: `https://premiumfeatures.roblox.com/v1/users/${userId}/validate-membership`,
+      options: {
+        method: 'GET',
+        jar: jar,
+        resolveWithFullResponse: true
+      }
+    }
+    return http(httpOpt)
+      .then(function (res) {
+        if (res.statusCode === 200) {
+          resolve(toString(res.body) === 'true')
+        } else {
+          const body = JSON.parse(res.body) || {}
+          if (body.errors && body.errors.length > 0) {
+            const errors = body.errors.map((e) => {
+              return e.message
             })
-    })
+            reject(new Error(`${res.statusCode} ${errors.join(', ')}`))
+          }
+        }
+      })
+  })
 }
 
-exports.func = function(args) {
-    const jar = args.jar
-    return getPremium(jar, args.userId)
+exports.func = function (args) {
+  const jar = args.jar
+  return getPremium(jar, args.userId)
 }

--- a/lib/user/getPremium.js
+++ b/lib/user/getPremium.js
@@ -11,7 +11,7 @@ exports.optional = ['jar']
  * @category User
  * @alias getPremium
  * @param {number} userId - The id of the user.
- * @returns {Promise<void>}
+ * @returns {Promise<boolean>}
  * @example const noblox = require("noblox.js")
  * // Login using your cookie
  * const hasPremium = await noblox.getPremium(123456)

--- a/lib/user/getPremium.js
+++ b/lib/user/getPremium.js
@@ -1,6 +1,5 @@
 // Includes
 const http = require('../util/http.js').func
-const getGeneralToken = require('../util/getGeneralToken.js').func
 
 // Args
 exports.required = ['userId']
@@ -8,18 +7,18 @@ exports.optional = ['jar']
 
 // Docs
 /**
- * Gets a user's premium status.
+ * Gets whether or not a user has premium.
  * @category User
- * @alias acceptFriendRequest
+ * @alias getPremium
  * @param {number} userId - The id of the user.
  * @returns {Promise<void>}
  * @example const noblox = require("noblox.js")
  * // Login using your cookie
- * const hasPremium = await noblox.getPremiumStatus(123456)
+ * const hasPremium = await noblox.getPremium(123456)
  **/
 
 // Define
-function getPremiumStatus(jar, userId) {
+function getPremium(jar, userId) {
     return new Promise((resolve, reject) => {
         const httpOpt = {
             url: `https://premiumfeatures.roblox.com/v1/users/${userId}/validate-membership`,
@@ -48,5 +47,5 @@ function getPremiumStatus(jar, userId) {
 
 exports.func = function(args) {
     const jar = args.jar
-    return getPremiumStatus(jar, args.userId)
+    return getPremium(jar, args.userId)
 }

--- a/lib/user/getPremium.js
+++ b/lib/user/getPremium.js
@@ -31,7 +31,7 @@ function getPremium (jar, userId) {
     return http(httpOpt)
       .then(function (res) {
         if (res.statusCode === 200) {
-          resolve(toString(res.body) === 'true')
+          resolve(res.body === 'true')
         } else {
           const body = JSON.parse(res.body) || {}
           if (body.errors && body.errors.length > 0) {

--- a/lib/user/getPremiumStatus.js
+++ b/lib/user/getPremiumStatus.js
@@ -1,0 +1,52 @@
+// Includes
+const http = require('../util/http.js').func
+const getGeneralToken = require('../util/getGeneralToken.js').func
+
+// Args
+exports.required = ['userId']
+exports.optional = ['jar']
+
+// Docs
+/**
+ * Gets a user's premium status.
+ * @category User
+ * @alias acceptFriendRequest
+ * @param {number} userId - The id of the user.
+ * @returns {Promise<void>}
+ * @example const noblox = require("noblox.js")
+ * // Login using your cookie
+ * const hasPremium = await noblox.getPremiumStatus(123456)
+ **/
+
+// Define
+function getPremiumStatus(jar, userId) {
+    return new Promise((resolve, reject) => {
+        const httpOpt = {
+            url: `https://premiumfeatures.roblox.com/v1/users/${userId}/validate-membership`,
+            options: {
+                method: 'GET',
+                jar: jar,
+                resolveWithFullResponse: true
+            }
+        }
+        return http(httpOpt)
+            .then(function(res) {
+                if (res.statusCode === 200) {
+                    resolve(res.body == 'true')
+                } else {
+                    const body = JSON.parse(res.body) || {}
+                    if (body.errors && body.errors.length > 0) {
+                        const errors = body.errors.map((e) => {
+                            return e.message
+                        })
+                        reject(new Error(`${res.statusCode} ${errors.join(', ')}`))
+                    }
+                }
+            })
+    })
+}
+
+exports.func = function(args) {
+    const jar = args.jar
+    return getPremiumStatus(jar, args.userId)
+}

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1370,6 +1370,11 @@ declare module "noblox.js" {
     function getPlayers(group: number, rolesetId: number[] | number, sortOrder?: SortOrder, limit?: number, jar?: CookieJar): Promise<GroupUser[]>;
 
     /**
+     * Gets whether or not a user has premium.
+     */
+    function getPremium(userId: number, jar?: CookieJar): Promise<boolean>;
+
+    /**
      * Gets `rank` of user with `userId` in `group` and caches according to settings.
      */
     function getRankInGroup(group: number, userId: number): Promise<number>;


### PR DESCRIPTION
Added a new function `getPremium()` that takes a user id, and returns `true` or `false` depending on whether the user with the given userId has premium or not. This uses the following endpoint:
`https://premiumfeatures.roblox.com/v1/users/${userId}/validate-membership`
This endpoint requires the bot to be logged in.
Feel free to user a better name than `getPremium`.

`// login with cookie`
`const hasPremium = await noblox.getPremium(123456)`
