### PR TITLE
Remove promise.allSettled and 12.9.0 dependency added by (#254)

### DIFF
--- a/lib/user/getGroups.js
+++ b/lib/user/getGroups.js
@@ -22,11 +22,14 @@ function getGroups (userId) {
     const requests = [
       constructRequest(`//groups.roblox.com/v2/users/${userId}/groups/roles`),
       constructRequest(`//groups.roblox.com/v1/users/${userId}/groups/primary/role`)
-    ]
+    ].map(promise => promise.then(
+      val => ({ status: 'fulfilled', value: val }),
+      rej => ({ status: 'rejected', reason: rej })
+    ))
 
     const result = []
 
-    Promise.allSettled(requests).then(async (promiseResponses) => {
+    Promise.all(requests).then(async (promiseResponses) => {
       let responses = promiseResponses.map(response => response.value)
       const failedResponse = (responses[0].statusCode !== 200 || !responses[0].body) // we only check the first request because the second one errors if a primary is not set
 

--- a/lib/user/getPlayerInfo.js
+++ b/lib/user/getPlayerInfo.js
@@ -26,9 +26,12 @@ function getPlayerInfo (userId) {
       constructRequest(`//friends.roblox.com/v1/users/${userId}/followings/count`),
       constructRequest(`//friends.roblox.com/v1/users/${userId}/followers/count`),
       getPageResults({ url: `//users.roblox.com/v1/users/${userId}/username-history`, query: {}, limit: 1000 })
-    ]
+    ].map(promise => promise.then(
+      val => ({ status: 'fulfilled', value: val }),
+      rej => ({ status: 'rejected', reason: rej })
+    ))
 
-    Promise.allSettled(requests).then((promiseResponses) => {
+    Promise.all(requests).then((promiseResponses) => {
       const responses = promiseResponses.map(response => response.value)
       const usersResponse = responses[0]
       const userBody = usersResponse ? usersResponse.body : {}

--- a/package.json
+++ b/package.json
@@ -4,9 +4,6 @@
   "description": "A Node.js wrapper for ROBLOX. (original from sentanos)",
   "main": "lib/index.js",
   "types": "typings/index.d.ts",
-  "engines": {
-    "node": ">=12.9"
-  },
   "scripts": {
     "docs": "jsdoc -c jsDocsConfig.json -r -t ./node_modules/better-docs",
     "lint": "eslint lib/",


### PR DESCRIPTION
Replaces all `Promise.allSettled()` usage with `Promise.all()` and `.map()` as referenced by (#283). In turn, this should remove the `node >=12.9.0` requirement added by #254.

I have tested on `node 11.15.0` with regard to the changed methods, `getPlayerInfo()` and `getGroups()`.

I cannot comment in regard to other incompatibilities that may have been introduced outside of `promise.allSettled()`.