### PR TITLE
Update getUserTransactions() endpoint version and code example

### DIFF
--- a/lib/user/getUserTransactions.js
+++ b/lib/user/getUserTransactions.js
@@ -9,7 +9,6 @@ exports.optional = ['transactionType', 'limit', 'cursor', 'jar']
  * Get a user's transactions.
  * @category User
  * @alias getUserTransactions
- * @param {number} userId - The id of the user.
  * @param {("Sale" | "Purchase" | "AffiliateSale" | "DevEx" | "GroupPayout" | "AdImpressionPayout")} [transactionType=Sale] - The type of transactions being fetched.
  * @param {Limit=} [limit=100] - The number of transactions being fetched each request. | [10, 25, 50, 100]
  * @param {string=} cursor - The previous or next page cursor.

--- a/lib/user/getUserTransactions.js
+++ b/lib/user/getUserTransactions.js
@@ -11,17 +11,17 @@ exports.optional = ['transactionType', 'limit', 'cursor', 'jar']
  * @alias getUserTransactions
  * @param {number} userId - The id of the user.
  * @param {("Sale" | "Purchase" | "AffiliateSale" | "DevEx" | "GroupPayout" | "AdImpressionPayout")} [transactionType=Sale] - The type of transactions being fetched.
- * @param {Limit=} [limit=10] - The number of transactions being fetched each request.
+ * @param {Limit=} [limit=100] - The number of transactions being fetched each request. | [10, 25, 50, 100]
  * @param {string=} cursor - The previous or next page cursor.
  * @returns {Promise<TransactionPage>}
  * @example const noblox = require("noblox.js")
- * let transactions = await noblox.getUserTransactions(123456, "Sale", 10)
+ * let transactions = await noblox.getUserTransactions("Sale", 10)
 **/
 
 function getTransactions (userId, transactionType, limit, cursor, jar) {
   return new Promise((resolve, reject) => {
     const httpOpt = {
-      url: `https://economy.roblox.com/v1/users/${userId}/transactions?limit=${limit}&transactionType=${transactionType}&cursor=${cursor}`,
+      url: `https://economy.roblox.com/v2/users/${userId}/transactions?limit=${limit}&transactionType=${transactionType}&cursor=${cursor}`,
       options: {
         method: 'GET',
         resolveWithFullResponse: true,

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -691,6 +691,8 @@ declare module "noblox.js" {
 
     interface TransactionItem
     {
+        id: number;
+        transactionType: string;
         created: Date;
         isPending: boolean;
         agent: TransactionAgent;


### PR DESCRIPTION
`getUserTransactions()` is using a removed endpoint; updating to `v2` fixes it; also corrected the code example for JSDocs. Appears to be an unbreaking change.

JSDocs had example usage providing a `userId` which isn't reflected in `index.d.ts`, the endpoint only works on the authenticated users so it is now removed from documentation.

Thank Jullian's ranting for the undocumented solution.

![image](https://user-images.githubusercontent.com/34300238/111413094-015c6600-86b4-11eb-9ca9-18f904109802.png)

![image](https://user-images.githubusercontent.com/34300238/111413321-69ab4780-86b4-11eb-8878-e19dd9bb40cb.png)
