### PR TITLE
Fixes getGroups() cannot read property of null typeError.

### DIFF
--- a/lib/user/getGroups.js
+++ b/lib/user/getGroups.js
@@ -45,7 +45,7 @@ function getGroups (userId) {
 
       const groupRoleData = responses[0].data
       if (groupRoleData) {
-        const primaryGroupId = responses[1].group && responses[1].group.id
+        const primaryGroupId = responses[1] && responses[1].group && responses[1].group.id
 
         const groupThumbails = await constructRequest(`https://thumbnails.roblox.com/v1/groups/icons?groupIds=${groupRoleData.map(data => data.group.id).join(',')}&size=150x150&format=Png&isCircular=false`)
 


### PR DESCRIPTION
The endpoint `https://groups.roblox.com/v1/users/${userId}/groups/primary/role` returns `null` when the user has no primary group selected. 

The previous code did not require the response to exist and thus threw `UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'group' of null` when running `getGroups()` on a user with no groups or no primary group selected. This change fixes the issue, and causes `[]` to return when the user has no group, and `isPrimary: false` for all objects if the user is in multiple groups, but no group is primary.

Optional chaining was not used to preserve backwards compatibility.

**Example UserID:** `2416399685`
Before:
![](https://i.imgur.com/Jz2RyVF.png)

After:
![](https://i.imgur.com/a09yXhR.png)