### PR TITLE
Using a ternary operator when setting the primaryGroupId variable.

### DIFF
--- a/lib/user/getGroups.js
+++ b/lib/user/getGroups.js
@@ -48,7 +48,7 @@ function getGroups (userId) {
 
       const groupRoleData = responses[0].data
       if (groupRoleData) {
-        const primaryGroupId = responses[1] && responses[1].group && responses[1].group.id
+        const primaryGroupId = responses[1] ? responses[1].group.id : null;
 
         const groupThumbails = await constructRequest(`https://thumbnails.roblox.com/v1/groups/icons?groupIds=${groupRoleData.map(data => data.group.id).join(',')}&size=150x150&format=Png&isCircular=false`)
 


### PR DESCRIPTION
I've ran into a long list of issues with this function. If the user doesn't have a set primary group, it errors and throws a TypeError (not poggers). Switching to a simple ternary operator completely fixes this issue.