### PR TITLE
Implement getGroupFunds()

### DIFF
--- a/lib/group/getGroupFunds.js
+++ b/lib/group/getGroupFunds.js
@@ -1,0 +1,43 @@
+// Includes
+const http = require('../util/http.js').func
+
+// Args
+exports.required = ['group']
+exports.optional = ['jar']
+
+// Docs
+/**
+ * Gets the amount of robux in a group.
+ * @category Group
+ * @alias getGroupFunds
+ * @param {number} group - The id of the group
+ * @returns {Promise<number>}
+ * @example const noblox = require("noblox.js")
+ * // Login using your cookie (optional if group funds are public)
+ * let robux = await noblox.getGroupFunds(9997719)
+**/
+
+// Define
+function getGroupFunds (group, jar) {
+  return http({
+    url: `//economy.roblox.com/v1/groups/${group}/currency`,
+    options: {
+      jar: jar,
+      resolveWithFullResponse: true
+    }
+  })
+    .then(({ statusCode, body }) => {
+      const { robux, errors } = JSON.parse(body)
+      if (statusCode === 200) {
+        return robux
+      } else if (statusCode === 400 || statusCode === 403) {
+        throw new Error(`${errors[0].message} | groupId: ${group}`)
+      } else {
+        throw new Error(`An unknown error occurred with getGroupFunds() | [${statusCode}] groupId: ${group}`)
+      }
+    })
+}
+
+exports.func = function ({ group, jar }) {
+  return getGroupFunds(group, jar)
+}

--- a/test/group.test.js
+++ b/test/group.test.js
@@ -1,4 +1,4 @@
-const { changeRank, getAuditLog, getGroup, getGroupTransactions, getJoinRequests, getLogo, getPlayers, getRankInGroup, getRankNameInGroup, getRole, getRolePermissions, getRoles, getShout, getWall, setRank, shout, setCookie } = require('../lib')
+const { changeRank, getAuditLog, getGroup, getGroupFunds, getGroupTransactions, getJoinRequests, getLogo, getPlayers, getRankInGroup, getRankNameInGroup, getRole, getRolePermissions, getRoles, getShout, getWall, setRank, shout, setCookie } = require('../lib')
 
 beforeAll(() => {
   return new Promise(resolve => {
@@ -102,6 +102,12 @@ describe('Group Methods', () => {
         memberCount: expect.any(Number),
         publicEntryAllowed: expect.any(Boolean)
       })
+    })
+  })
+
+  it('getGroupFunds() returns amount of robux in group funds', () => {
+    return getGroupFunds(9997719).then((res) => {
+      return expect(res).toEqual(expect.any(Number))
     })
   })
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1307,6 +1307,11 @@ declare module "noblox.js" {
     function groupPayout(group: number, member: number | number[], amount: number | number[], recurring?: boolean, usePercentage?: boolean, jar?: CookieJar): Promise<void>;
 
     /**
+     * Gets the amount of robux in a group.
+     */
+    function getGroupFunds(group: number): Promise<number>;
+
+    /**
      * `Accepts user with `username` into `group`. Note that `username` is case-sensitive.
      */
     function handleJoinRequest(group: number, userId: string, accept: boolean, jar?: CookieJar): Promise<void>;
@@ -1580,7 +1585,7 @@ declare module "noblox.js" {
      */
     function getInventoryById(userId: number, assetTypeId: number, sortOrder?: SortOrder, limit?: number, jar?: CookieJar): Promise<InventoryEntry[]>;
 
-    ///Trades
+    /// Trades
 
     /**
      * Check if the current user can trade with another user.


### PR DESCRIPTION
Returns the amount of robux available in group funds for a given group. A test case is included.

Valid use cases can include making notifiers for when a group reaches 100,000R for DevEx or visualizing profits over time. Added by request in the `noblox.js` Discord.

---

There were discussions in the past about avoiding this endpoint because it could be used for abuse with `groupPayout()`; but in retrospect, people can already do a 100% group payout without this endpoint.

https://github.com/suufi/noblox.js/blob/0ee12320bb998475ac320082a0a1681d282688bf/lib/group/groupPayout.js#L18
https://github.com/suufi/noblox.js/blob/0ee12320bb998475ac320082a0a1681d282688bf/lib/group/groupPayout.js#L85