### PR TITLE
Fix unblock error message

### DIFF
--- a/lib/user/unblock.js
+++ b/lib/user/unblock.js
@@ -40,7 +40,7 @@ function unblock (jar, token, userId) {
         if (res.statusCode === 200) {
           const body = res.body
           if (!body.success) {
-            reject(new Error(body.message))
+            reject(new Error(body.error || body.message))
           }
           resolve()
         } else {


### PR DESCRIPTION
I have seen a case where the error message is returned as a string in body.error.
I have added this as an OR to make sure if Roblox sometimes returns the error as body.message, these are not missed.