### PR TITLE
Fix uploadItem() code example

### DIFF
--- a/lib/asset/uploadItem.js
+++ b/lib/asset/uploadItem.js
@@ -12,18 +12,18 @@ exports.optional = ['groupId', 'jar']
  * @category Assets
  * @alias uploadItem
  * @param {string} name - The name of the asset.
- * @param {number} assetType - The id for the asset type.
+ * @param {number} assetType - The [id for the asset type]{@link https://developer.roblox.com/en-us/api-reference/enum/AssetType}.
  * @param {ReadStream} file - The read stream for the asset being uploaded.
  * @param {number=} groupId - The group to upload the asset to.
  * @returns {Promise<UploadItemResponse>}
  * @example const noblox = require("noblox.js")
  * const fs = require("fs")
  * // Login using your cookie
- * noblox.upload("A cool decal.", 13, fs.createReadStream("./Image.png"))
+ * noblox.uploadItem("A cool decal.", 13, fs.createReadStream("./Image.png"))
 **/
 
 // Define
-function upload (jar, file, name, assetType, groupId) {
+function uploadItem (jar, file, name, assetType, groupId) {
   return new Promise((resolve, reject) => {
     return getVerification({
       url: 'https://www.roblox.com/build/upload',
@@ -78,5 +78,5 @@ function upload (jar, file, name, assetType, groupId) {
 }
 
 exports.func = function (args) {
-  return upload(args.jar, args.file, args.name, args.assetType, args.groupId)
+  return uploadItem(args.jar, args.file, args.name, args.assetType, args.groupId)
 }


### PR DESCRIPTION
Code example incorrectly uses `upload()` instead of `uploadItem()`. I also made a [hyperlink to the Developer Wiki for a list of AssetType enums](https://developer.roblox.com/en-us/api-reference/enum/AssetType).

https://github.com/suufi/noblox.js/blob/5137e625223bf9dba27c83e0ad089e49e95e0f1c/lib/asset/uploadItem.js#L22

![](https://i.imgur.com/fWmEA3t.png)