### PR TITLE
Remove Role.ID in favour of role.id

### DIFF
--- a/examples/cleanPlayers.js
+++ b/examples/cleanPlayers.js
@@ -53,7 +53,7 @@ rbx.setCookie(cookie)
     const targetRoles = []
 
     for (const role of groupRoles) {
-      if (options.roleset.includes(role.ID)) {
+      if (options.roleset.includes(role.id)) {
         targetRoles.push(role)
       }
 
@@ -69,7 +69,7 @@ rbx.setCookie(cookie)
     }
 
     options.roleset = targetRoles.map((role) => {
-      return role.ID
+      return role.id
     })
 
     let totalPlayers = 0

--- a/examples/savePlayers.js
+++ b/examples/savePlayers.js
@@ -57,7 +57,7 @@ rbx.setCookie(cookie)
       targetRoles = groupRoles
     } else {
       for (const role of groupRoles) {
-        if (options.roleset.includes(role.ID)) {
+        if (options.roleset.includes(role.id)) {
           targetRoles.push(role)
         }
 
@@ -74,7 +74,7 @@ rbx.setCookie(cookie)
     }
 
     options.roleset = targetRoles.map((role) => {
-      return role.ID
+      return role.id
     })
 
     let totalPlayers = 0

--- a/lib/group/changeRank.js
+++ b/lib/group/changeRank.js
@@ -48,7 +48,7 @@ exports.func = function (args) {
                 throw new Error('Group members cannot be demoted to guest.')
               }
 
-              return setRank({ group: group, target: target, rank: found.ID, jar: jar })
+              return setRank({ group: group, target: target, rank: found.id, jar: jar })
                 .then(function () {
                   return { newRole: found, oldRole: role }
                 })

--- a/lib/group/getRole.js
+++ b/lib/group/getRole.js
@@ -34,7 +34,7 @@ function getRole (roles, roleQuery) {
       } else if (typeof roleQuery === 'string') {
         find = entities.decodeHTML(role.name)
       } else if (typeof roleQuery === 'number' || roleQuery > 255) {
-        find = role.ID
+        find = role.id
       }
 
       if (roleQuery === find) {

--- a/lib/group/getRoles.js
+++ b/lib/group/getRoles.js
@@ -41,7 +41,6 @@ function getRoles (group) {
           for (let i = 0; i < roles.length; i++) {
             const role = roles[i]
             role.ID = role.id
-            delete role.id
           }
           resolve(roles)
         }

--- a/lib/group/setRank.js
+++ b/lib/group/setRank.js
@@ -35,7 +35,7 @@ function setRank (jar, xcsrf, group, target, role) {
           'X-CSRF-TOKEN': xcsrf
         },
         body: JSON.stringify({
-          roleId: role.ID
+          roleId: role.id
         })
       }
     }


### PR DESCRIPTION
Not sure why we convert role.id to role.ID? I imagine it was in favour of past consistency.
The typings show role has an `id` field, not `ID`. This is not the case.
This brings the library in-line with the typings, but retains backwards compatibility. 