### PR TITLE
Fix revertRanks.js example

### DIFF
--- a/examples/revertRanks.js
+++ b/examples/revertRanks.js
@@ -50,7 +50,7 @@ async function revertAuditLogItems (auditLogItems) {
     const setRankOptions = {
       group: options.group,
       target: auditLogItem.TargetId,
-      roleset: auditLogItem.OldRoleSetId
+      rank: auditLogItem.OldRoleSetId
     }
 
     await rbx.setRank(setRankOptions)


### PR DESCRIPTION
Fixes the `revertRanks.js` example snippet was broken by https://github.com/suufi/noblox.js/commit/8e4701d1b36aa1ed71d5b6c9aefa8d6c3d184190, which changed the field name `roleset` to `rank`.

Tested using the noblox.js group, and one of my private groups.

![image](https://user-images.githubusercontent.com/34300238/115094331-2595a780-9eeb-11eb-9fc9-b62f0c76aa96.png)
